### PR TITLE
Typo/consistency stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,24 @@
-# Clearhaus 3D-Secure v2 API Documentation #
+# Clearhaus 3-D Secure v2 API Documentation
 
-## Status ##
+## Status
 
-We at  Clearhaus are currently in the process of developing our 3D Secure
-version 2 Server implementation. Post-implementation we need certification with
-EMVCo, on-site PCI audit followed by certification with card schemes and
-deployment to production.
+We at Clearhaus are currently in the process of developing our 3-D Secure
+version 2 implementation. Post-implementation we need certification with EMVCo,
+on-site PCI audit followed by certification with card schemes and deployment to
+production.
 
 It is too early to make any promises about schedule for deployment or, in fact,
-most things.  But we are working on it.
+most things. But we are working on it.
 
 Using the terminology from the specification, we will be responsible for the
-3DS Server, while we view our technical partners as 3DS Requestors.
+3DS Server, while we consider our technical partners to be 3DS Requestors.
 
-## Specification ##
+## Specification
 
-The 3D-Secure v2 specification is defined by EMVCo, their list of 3D-Secure v2
+The 3-D Secure v2 specification is defined by EMVCo, their list of 3-D Secure v2
 documentation can be found [on their documentation
-page.](https://www.emvco.com/document-search/?action=search_documents&publish_date=&emvco_document_version=&emvco_document_book=&px_search=&emvco_document_technology%5B%5D=3-d-secure)
+page](https://www.emvco.com/document-search/?action=search_documents&publish_date=&emvco_document_version=&emvco_document_book=&px_search=&emvco_document_technology%5B%5D=3-d-secure).
 
 Specifically, the primary documentation can be found in [EMV® 3-D Secure
 Protocol and Core Functions
-Specification.](https://www.emvco.com/wp-content/uploads/documents/EMVCo_3DS_Spec_v220_122018.pdf)
-The spec is currently at version 2.2.0.
+Specification](https://www.emvco.com/wp-content/uploads/documents/EMVCo_3DS_Spec_v220_122018.pdf).


### PR DESCRIPTION
Nothing important to be seen.
Removed mentioning the current version number.
Checked that the links do work.