### PR TITLE
Suggestions for initial documentation

### DIFF
--- a/source/3dsmethod.rst
+++ b/source/3dsmethod.rst
@@ -6,10 +6,10 @@
 If the :ref:`preauth-usage` response includes a `threeDSMethodURL`, the 3DS Method *must* be
 invoked.
 
-If not, continue the :ref:`auth-usage` with ``"threeDSCompInd": "U"``, to
+If not, continue with the :ref:`auth-usage` and include ``"threeDSCompInd": "U"``, to
 indicate that the 3DS Method was not available.
 
-1. Create JSON object containing `threeDSServerTransID` from the `/preauth`
+1. Create a JSON object containing `threeDSServerTransID` from the `/preauth`
    call:
 
    .. code-block:: json
@@ -20,7 +20,7 @@ indicate that the 3DS Method was not available.
      }
 
 2. Render a hidden HTML iframe in the Cardholder browser and send a form with a
-   field name `threeDSMethodData` containing the above JSON Base64URL-encoded
+   field named `threeDSMethodData` containing the above JSON as Base64URL-encoded
    to the `threeDSMethodURL`.
 
    Below is a suggestion of what you can do:
@@ -97,7 +97,7 @@ indicate that the 3DS Method was not available.
       threeDSMethodData=eyJ0aHJlZURTTWV0aG9kRGF0YSI6ICJkNDYxZjEwNS0xNzkyLTQwN2YtOTVmZi05YTQ5NmZkOTE4YTkifQ==
 
 
-   And the decoded value is like:
+   The decoded value is like:
 
    .. code-block:: json
 

--- a/source/3dsmethod.rst
+++ b/source/3dsmethod.rst
@@ -85,7 +85,7 @@ indicate that the 3DS Method was not available.
 
 3. When the 3D Method call is finished, the browser iframe will be redirected to
    ``threeDSMethodNotificationURL``.
-   If the callback is not recieved in 10 seconds, proceed with step 4.
+   If the callback is not received in 10 seconds, proceed with step 4.
 
    The method will be ``POST`` and will contain a form with the value
    ``threeDSMethodData``, that can be used to identify the request.

--- a/source/_static/ares_210.html
+++ b/source/_static/ares_210.html
@@ -532,11 +532,11 @@ One of:
 <div class='enumKey'>U</div>
 <div class='enumValue'>Authentication/ Account Verification Could Not Be Performed; Technical or other problem, as indicated in ARes or RReq</div>
 <div class='enumKey'>A</div>
-<div class='enumValue'>Attempts Processing Performed; Not Authenticated/Verified , but a proof of attempted authentication/verificat ion is provided</div>
+<div class='enumValue'>Attempts Processing Performed; Not Authenticated/Verified , but a proof of attempted authentication/verification is provided</div>
 <div class='enumKey'>C</div>
 <div class='enumValue'>Challenge Required; Additional authentication is required using the CReq/CRes</div>
 <div class='enumKey'>R</div>
-<div class='enumValue'>Authentication/ Account Verification Rejected; Issuer is rejecting authentication/verificat ion and request that authorisation not be attempted.</div>
+<div class='enumValue'>Authentication/ Account Verification Rejected; Issuer is rejecting authentication/verification and request that authorisation not be attempted.</div>
 </div>
 <div class='conditions'>
 <div class=''>

--- a/source/auth.rst
+++ b/source/auth.rst
@@ -18,7 +18,7 @@ This near-pseudocode describes the flow your code should perform.
 
 1. Generate the input as described in :ref:`the reference <auth-input>`.
 
-2. Send the request to 3dsecure.io. Consult the :ref:`requests guide
+2. Send the request to the 3-D Secure Server. Consult the :ref:`requests guide
    <requests>` for information about how to make requests.
    A simple request performed using cURL:
 
@@ -81,7 +81,7 @@ To check if a transaction was successful:
 1. Parse as JSON
 2. Check that ``messageType`` is ``ARes``
 
-Please note that a 3dsecure.io transaction is considered successful even if
+Please note that a 3-D Secure Server transaction is considered successful even if
 ``transStatus`` is ``N``. There is a difference between an *authentication
 failure* and a *transaction failure*.
 

--- a/source/auth.rst
+++ b/source/auth.rst
@@ -4,7 +4,7 @@
 /auth endpoint
 ##############
 
-The ``/auth`` call is used to initiate a 3-D Secure v2 authentication.
+The ``/auth`` endpoint is used to initiate a 3-D Secure v2 authentication.
 
 ************
 Request flow
@@ -85,8 +85,8 @@ Please note that a 3-D Secure Server transaction is considered successful even i
 ``transStatus`` is ``N``. There is a difference between an *authentication
 failure* and a *transaction failure*.
 
-Failure
-=======
+Errors
+======
 
 In all but the rarest cases an ``Erro`` message is returned on an error.
 

--- a/source/challenge_flow.rst
+++ b/source/challenge_flow.rst
@@ -6,7 +6,7 @@ Challenge flow
 Browser Challenge
 -----------------
 
-Create a CReq :ref:`as decribed <creq-format>`, using the transaction ID's
+Create a CReq :ref:`as described <creq-format>`, using the transaction ID's
 received in the :ref:`authentication response <auth-response>`.
 
 Add an iframe to the users browser, either statically or using javascript.

--- a/source/challenge_flow.rst
+++ b/source/challenge_flow.rst
@@ -71,9 +71,9 @@ Fill out the form inputs and submit them to the ACS URL in the iframe.
 .. TODO: Describe the callback.
 
 After the challenge has finished, the browser will be redirected to the
-``notificationURL``, where it will POST two values, the ``threeDSSessionData``
-that was supplied before, as well as a "final" challenge result ``CRes`` value.
-The final CRes looks something like this:
+``notificationURL``, where it will POST two values, 1) the ``threeDSSessionData``
+that was supplied before, as well as 2) a "final" challenge result ``CRes`` value.
+The final `CRes` looks something like this:
 
 
 .. code-block:: json
@@ -88,7 +88,7 @@ The final CRes looks something like this:
      "transStatus": "Y"
    }
 
-Here ``transStatus`` will be either ``Y`` or ``N``, if the value is ``Y`` you
+Here ``transStatus`` will be either ``Y`` or ``N``. If the value is ``Y`` you
 can use the :ref:`postauth-usage` to fetch the results of the challenge.
 
 Handling timeouts
@@ -103,4 +103,4 @@ SDK Challenge
 -------------
 
 The challenge should be handled by the SDK, please refer to the SDK
-documentation.
+specification for further information.

--- a/source/getting-started.rst
+++ b/source/getting-started.rst
@@ -47,7 +47,7 @@ BRW
   The message value is ``02``.
 
 3RI
-  Authentications performed wihtout cardholder involvement, used for e.g.
+  Authentications performed without cardholder involvement, used for e.g.
   getting 3-D Secure values for subsequent recurring transactions.
   The message value is ``03``.
 

--- a/source/getting-started.rst
+++ b/source/getting-started.rst
@@ -7,7 +7,7 @@ Getting Started
 Sandbox environment
 ===================
 
-Included in this service is a sandbox environment to ease integration. It is
+A sandbox environment is included to ease integration. It is
 provided as a service for continuous integration and for live tests.
 This is our own implementation so there will be some discrepancies with the
 production endpoint. The production endpoint is to be used only for production requests.
@@ -74,17 +74,15 @@ parameter definition. Brief descriptions are:
   Under certain circumstances, the authentication flow will end successfully
   here, this is called *frictionless* flow.
 
-  
-
 /postauth
   Used when the ``/auth`` did not result in a frictionless flow, this endpoint
-  returns the result of the challenge the cardholder performed.  In this case
-  the flow is called a *challenge* flow.
+  returns the result of the challenge performed by the cardholder. In this case
+  the flow is called a *challenge* flow. Read more about this in :ref:`3ds_challenge_flow`.
 
 Overview of Authentication Flow
 ===============================
 
-This figure illustrates the simplified authentication flow from a requestor
+This figure illustrates the authentication flow from a requestor
 point of view:
 
 .. image:: authentication.svg
@@ -94,31 +92,30 @@ point of view:
 The following describes the individual points in the diagram:
 
 1. A call to the :ref:`preauth-endpoint` is performed if the
-   request originator is a cardholder using a browser, as opposed to using a
+   request originator is a cardholder using a browser. This is opposed to using a
    SDK or the authentication being Requestor initiated.
 2. The :ref:`preauth-response` contains:
 
-   * Information that might be usable in determining whether to fall back to
+   - Information that might be usable in determining whether to fall back to
      3-D Secure v1.
+   - An optional `threeDSMethodURL` that is invoked in the user browser.
 
-   * An optional `threeDSMethodURL` that is invoked in the user browser.
-
-3. The cardholder browser invokes the `threeDSMethodURL`, to allow the ACS to
+3. The cardholder browser invokes the received `threeDSMethodURL`, to allow the ACS to
    fingerprint the browser. See the :ref:`3ds_method` guide.
 4. The Requestor uses the :ref:`auth-endpoint` to send the information needed
-   for 3dsecure.io to assemble a ``AReq`` message.
+   for the 3-D Securer Server to assemble a ``AReq`` message.
 5. The Auth :ref:`auth-response` is an ``ARes``, as defined by the specification.
 
    This ``ARes`` contains either:
 
-   - The authentication result (Called *frictionless* flow)
-   - Information about how to proceed with the challenge (Called *challenge* flow)
+   - The authentication result (*frictionless* flow)
+   - Information about how to proceed with the challenge (*challenge* flow)
    - Information stating why the challenge cannot continue
 
-6. The cardholder completes the challenge on the cardholders device.  See the
+6. The cardholder completes the challenge on the their device. See the
    :ref:`3ds_challenge_flow` guide.
 7. The ACS informs the Requestor about the challenge result through a callback.
-8. The :ref:`postauth-endpoint` is used the fetch the results of the
+8. The :ref:`postauth-endpoint` is used to fetch the results of the
    authentication.
 9. Nominally a ``RReq`` is returned to the Requestor. Parameters are detailed
    in the :ref:`postauth response <postauth-response>` section.

--- a/source/getting-started.rst
+++ b/source/getting-started.rst
@@ -4,27 +4,26 @@
 Getting Started
 ###############
 
-About this service
-==================
+Sandbox environment
+===================
 
 Included in this service is a sandbox environment to ease integration. It is
 provided as a service for continuous integration and for live tests.
 This is our own implementation so there will be some discrepancies with the
-production endpoint.
+production endpoint. The production endpoint is to be used only for production requests.
 
 .. warning::
   Under *no* circumstances may real card numbers or other cardholder
   information be sent to the sandbox.
 
-The production endpoint is to be used only for production requests.
-
 Authentication scenarios
 ========================
 
-Authentications can be split up broadly by two variables which are included in
-every transaction, ``messageCategory`` and ``deviceChannel``.
+Authentications can be described broadly by the two variables below which are included in
+every transaction.
 
-The two possible *message categories* are:
+Message categories (``messageCategory``)
+----------------------------------------
 
 Payment
   Used for the normal payment authentication flow.
@@ -35,7 +34,8 @@ Non-Payment
   The message value is ``02``.
 
 
-The three *device channels* are:
+Device channels (``deviceChannel``)
+-----------------------------------
 
 APP
   Authentications initiated on a mobile device, utilizing a dedicated 3-D
@@ -58,9 +58,9 @@ There are 3 API endpoints for this service, refer to :ref:`reference` for
 parameter definition. Brief descriptions are:
 
 /preauth
-  This is used when performing transactions from a browser [1]_, where it will
+  This is used when performing transactions from a browser (as opposed to using an SDK), where it will
   return an optional 3-D Secure Method URL, which is used for browser
-  fingerprinting.  This can support risk-based analysis and assist in ensuring
+  fingerprinting. This can support risk-based analysis and assist in ensuring
   a flow where the cardholder is not challenged.
 
   While in the transition period between 3-D Secure v1 and v2, this endpoint
@@ -68,9 +68,13 @@ parameter definition. Brief descriptions are:
   :ref:`3ds_versioning` guide.
 
 /auth
-  A single call to receive all the data that is needed for authentication [2]_.
+  A single call to receive all the data that is needed for authentication, 
+  except for the 3-D Secure Method URL used for fingerprinting when performing 
+  an authentication through a browser.
   Under certain circumstances, the authentication flow will end successfully
   here, this is called *frictionless* flow.
+
+  
 
 /postauth
   Used when the ``/auth`` did not result in a frictionless flow, this endpoint
@@ -118,7 +122,3 @@ The following describes the individual points in the diagram:
    authentication.
 9. Nominally a ``RReq`` is returned to the Requestor. Parameters are detailed
    in the :ref:`postauth response <postauth-response>` section.
-
-.. [1] as opposed to using an SDK.
-.. [2] except for the 3-D Secure Method URL used for fingerprinting when
-       performing an authentication through a browser.

--- a/source/index.rst
+++ b/source/index.rst
@@ -21,23 +21,18 @@ Introduction
 
   Currently this documentation only contains information about v2.1.0.
 
-If this is your first time here, please read this page.
+This is the documentation for the 3-D Secure Server provided by `3dsecure.io`_.
+It is a Software as a Service (SaaS) implementation, offering a language-agnostic
+HTTP API integration. This service supports all active versions of 3-D Secure version 2
+(``2.1.0``, ``2.2.0``) and our goal was to make the documentation work on it’s own.
+Nevertheless, you may need to refer to the specifications during the implementation.
 
-This is the documentation for `3dsecure.io`_, a 3-D Secure Server.  The
-implementation is a SAAS implementation, offering a language-agnostic HTTP API
-integration.
+A 3-D Secure Server is used for *cardholder authentication*. An authentication in 3-D Secure
+is the process of verifying cardholder involvement in e.g. a purchase. An authentication
+results from an *authentication flow* and proof of authentication is an *authentication value*.
+Get an overview of a 3-D Secure Server in :ref:`what-is-a-3-d-secure-server`
 
-A 3-D Secure Server is used for *cardholder authentication*.
-An authentication in 3-D Secure is the process of verifying cardholder
-involvement in e.g. a purchase. An authentication results from and
-*authentication flow* and proof of authentication is an *authentication value*.
-
-This service supports all active versions of 3-D Secure version 2 (``2.1.0``,
-``2.2.0``) and we have tried to make the documentation work on it's own.
-Nevertheles, you may need to refer to the specifications during the
-implementation.
-
-Who should integrate with this service:
+Who should integrate with this service
 =======================================
 
 Candidates for integrating with this service:
@@ -46,44 +41,43 @@ Candidates for integrating with this service:
 - Gateways
 - Merchants
 
-Why should you choose **3dsecure.io**?
-======================================
+Why choose this service by **3dsecure.io**?
+===========================================
 
-We of course believe that 3dsecure.io is a great service. Let us list a few
-reasons why.
+We believe our service is a great product! Let us list a few reasons why.
 
 Developed to have no downtime
-  Updates and deployments have been engineered as to have no downtime for
-  integrators.
+  Updates and deployments have been engineered to have no downtime
+  for integrators.
 
 No performance limit
   The service is highly scalable and has been engineered to be redundant.
 
 Sandbox service
-  We provide access to a sandbox service that allows for continus testing
-  against a "live" system.
+  We provide access to a sandbox service that allows for continuous testing
+  against a “live” system.
 
 Competitive pricing
   We offer plans you can grow with. Our pricing is aimed at both low scale
   users as well as high scale enterprise users.
 
-Dedicated dashboard
-  *(Not in production yet)* Use our dedicated dashboard to gain insight into
+Dedicated dashboard (under development)
+  Use our dedicated dashboard to gain insight into
   your 3-D Secure usage.
 
 Devoted team
   We take pride in our job and are dedicated to provide a great service.
 
-A Brief introduction to a 3-D Secure Server
+
+.. _what-is-a-3-d-secure-server:
+
+What is a 3-D Secure Server?
 ===========================================
 
-A 3-D Secure Server is used in the financial industry, to:
-
-    Facilitate cardholder *authentication* in preparation for e.g. making a
-    purchase.
-
-The specification is developed by EMVCo, who by `their own
-words <https://www.emvco.com/about/overview/>`_
+A 3-D Secure Server is used in the financial industry, to facilitate cardholder
+authentication in preparation for e.g. making a purchase. The specification is
+developed by EMVCo, who by `their own
+words <https://www.emvco.com/about/overview/>`_:
 
     EMVCo exists to facilitate worldwide interoperability and acceptance of
     secure payment transactions
@@ -93,7 +87,8 @@ The specification is public and can be found at `EMVCos document page
 included here for ease of access. This guide intends to be self-contained, such
 that you do not need to refer to the specification.
 
-Note: The following documents are all produced and copyrighted by `EMVCo <https://www.emvco.com/>`_.
+.. note::
+  The following documents are all produced and copyrighted by `EMVCo <https://www.emvco.com/>`_.
 
 .. list-table::
   :header-rows: 1
@@ -125,8 +120,7 @@ Note: The following documents are all produced and copyrighted by `EMVCo <https:
 Where to go from here
 =====================
 
-1. Sign up at `3dsecure.io <https://www.3dsecure.io>`_, this is out of scope of
-   this documentation.
+1. Sign up at `3dsecure.io <https://www.3dsecure.io>`_ (not covered by this documentation)
 2. Read the :ref:`getting-started` guide for getting an
    understanding of the authentication flow.
 3. Read the :ref:`requests` section to learn the prerequisites for requests.

--- a/source/postauth.rst
+++ b/source/postauth.rst
@@ -4,7 +4,7 @@
 /postauth endpoint
 ##################
 
-The ``/postauth`` is used to fetch the results of a challenge flow.
+The ``/postauth`` endpoint is used to fetch the results of a challenge flow.
 
 ************
 Request flow

--- a/source/postauth.rst
+++ b/source/postauth.rst
@@ -22,7 +22,7 @@ This near-pseudocode describes the flow your code should perform.
       }
 
 
-2. Send the request to 3dsecure.io. Consult the :ref:`requests guide
+2. Send the request to the 3-D Secure Server. Consult the :ref:`requests guide
    <requests>` for information about how to make requests.
    A simple request performed using cURL:
 
@@ -44,5 +44,5 @@ This near-pseudocode describes the flow your code should perform.
 See :ref:`the reference <postauth-input>` for the values returned.
 
 .. note::
-  The authentication cache expires 300 seconds after 3dsecure.io receives it
+  The authentication cache expires 300 seconds after the 3-D Secure Server receives it
   from the card scheme, it must be fetched before expiry.

--- a/source/preauth.rst
+++ b/source/preauth.rst
@@ -6,10 +6,8 @@
 
 The ``/preauth`` endpoint is used for two things:
 
-- Determine if card number is enrolled for 3-D Secure v2
-
-  This can be used to decide if you should fall back to using 3-D Secure
-  v1.0.2
+- Determine if card number is enrolled for 3-D Secure v2.
+  This can be used to decide if you should fall back to using 3-D Secure v1.0.2
 - 3DSMethod invocation information
 
 ************

--- a/source/preauth.rst
+++ b/source/preauth.rst
@@ -30,7 +30,7 @@ This near-pseudocode describes the flow your code should perform.
          "acctNumber": "9171598723598723"
        }
 
-2. Send the request to 3dsecure.io. Consult the :ref:`requests guide
+2. Send the request to the 3-D Secure Server. Consult the :ref:`requests guide
    <requests>` for information about how to make requests.
    A simple request performed using cURL:
 

--- a/source/preauth.rst
+++ b/source/preauth.rst
@@ -6,7 +6,7 @@
 
 The ``/preauth`` endpoint is used for two things:
 
-- Determine if Card Number is enrolled for 3-D Secure v2
+- Determine if card number is enrolled for 3-D Secure v2
 
   This can be used to decide if you should fall back to using 3-D Secure
   v1.0.2
@@ -69,14 +69,14 @@ This near-pseudocode describes the flow your code should perform.
 Response Data
 *************
 
-Successfull requests will have HTTP response code 200.
+Successful requests will have HTTP response code 200.
 
 .. _preauth-success:
 
 Success
 =======
 
-If the cardnumber is enrolled for 3-D Secure v2, the response might look
+If the card number is enrolled for 3-D Secure v2, the response might look
 something like:
 
 .. code-block:: json

--- a/source/reference.rst
+++ b/source/reference.rst
@@ -103,10 +103,10 @@ Output
 Challenge flow
 ==============
 
+.. _creq-format:
+
 Challenge request (CReq)
 ------------------------
-
-.. _creq-format:
 
 .. raw:: html
   :file: _static/creq.html

--- a/source/reference.rst
+++ b/source/reference.rst
@@ -5,7 +5,7 @@ Reference
 #########
 
 The *scenario selector* below can be used to narrow down the required fields
-for a selected authentication scenario. Please note these things:
+for a selected authentication scenario. Please note the following:
 
 1. When ``All`` is selected in both dropdowns, no type filters are applied.
    I.e. both ``sdkTransID`` and ``browserUserAgent`` is marked as required,

--- a/source/sandbox.rst
+++ b/source/sandbox.rst
@@ -172,7 +172,7 @@ Expected Outcome
 
 -----------------
 
-Successfull frictionless
+Successful frictionless
   A successful frictionless transaction.
 
 Endpoint under test
@@ -187,7 +187,7 @@ Expected Outcome
 
 -----------------
 
-Successfull frictionless attempt
+Successful frictionless attempt
   A successful frictionless transaction.
 
 Endpoint under test
@@ -207,7 +207,7 @@ Expected Outcome
   Challenge Testcases
   ===================
 
-  - Successfull frictionless
+  - Successful frictionless
     - [x] transStatus [Y, A]
       - [ ] AuthenticationType [01, 02, 03]
 
@@ -216,7 +216,7 @@ Expected Outcome
       - [ ] transStatusReason
     - [x] Filled/Empty cardholderInfo
 
-  - Successfull challenge
+  - Successful challenge
     - [ ] transStatus [C]
     - [ ] acsChallengeMandated [Y, N]
 

--- a/source/server-information.rst
+++ b/source/server-information.rst
@@ -32,11 +32,11 @@ Versions supported
 
 .. _requests:
 
-Making requests to 3dsecure.io
-==============================
+Making requests to the 3-D Secure Server
+========================================
 
 Request methods
-  All requests to 3dsecure.io are HTTP POST requests.
+  All requests to the 3-D Secure Server are HTTP POST requests.
 
 Request headers
   For all requests, the content type header must be

--- a/source/usage.rst
+++ b/source/usage.rst
@@ -7,7 +7,7 @@ API Usage
 
    - Insert link to 3dservice 1.0.2 MPI documentation.
 
-BRW device channel
+Authentication through browser (BRW device channel)
   1. Use the :ref:`/preauth <preauth-usage>` API call to determine 3-D Secure
      version.
 


### PR DESCRIPTION
This PR is branched out from #2 and contains the following suggestions: 
- Correction of spelling errors and a broken link.
- Suggestions for rephrasing of sentences and restructuring of content.
- Replacement of "3dsecure.io" with "3-D Secure Server", since 3dsecure.io also includes an MPI product. Furthermore, it makes it easier to integrate the [MPI docs](https://docs.3dsecure.io/) into this documentation when time allows it. 

Some suggestions not included in this PR.

- Add API endpoints to the [authentication flow figure](https://clearhaus.github.io/3DSv2-api-documentation/getting-started.html#overview-of-authentication-flow) mentioned in the text below the figure.
- Open external links in a new tab/window.
- The [Getting Started](https://clearhaus.github.io/3DSv2-api-documentation/getting-started.html) could benefit from explanations of the different parties involved, e.g. Issuer (ACS), Requestor, Cardholder. 
- Improve styling. Styling is a bit off various places e.g. links are not highlighted with a color, spacing in lists are off.
- The sidebar menu is a bit confusing due to the items being highlighted and indented, e.g. if clicking on: https://clearhaus.github.io/3DSv2-api-documentation/preauth.html the following is also highlighted: `3.2. /auth endpoint` and `3.3. /postauth endpoint`.

Feel free to use what makes sense :-) 