### PR TITLE
Document `transStatusReason=87` for Mastercard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,15 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.6'
-
-      - name: Install
-        run: pip install sphinx_rtd_theme sphinx
-
       - name: Build
-        run: sphinx-build -b html source $BUILD_DIR
+        run: make
 
       - name: Install AWS Cli
         run: pip install awscli

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,13 +5,14 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    env:
-      BUILD_DIR: build
     steps:
       - uses: actions/checkout@v3
 
       - name: Build
-        run: make
+        run: |
+          mkdir build
+          chmod 777 build
+          make
 
       - name: Install AWS Cli
         run: pip install awscli
@@ -23,7 +24,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: eu-west-1
         run: |
-          aws s3 sync $BUILD_DIR \
+          aws s3 sync build \
           s3://clrhs-prod-nonpci-docs-3dsecure-io/3dsv2 --delete
           aws cloudfront create-invalidation --distribution-id E7TJBG3FUU0TD --paths '/3dsv2/*'
 
@@ -34,5 +35,5 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: eu-west-1
         run: |
-          aws s3 sync $BUILD_DIR \
+          aws s3 sync build \
           s3://clrhs-prod-nonpci-docs-3dsecure-io/3dsv2 --dryrun --delete

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 # Minimal makefile for Sphinx documentation
 
-build:
-	docker run -ti --rm -v $$(pwd):/opt -w /opt -e USER_ID=$${UID} ddidier/sphinx-doc:2.2.1-1 make html
-
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
+
+build:
+	docker run --rm -v $$(pwd):/opt -w /opt -e USER_ID=$${UID} ddidier/sphinx-doc:2.2.1-1 make html
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/source/_static/ares_210.html
+++ b/source/_static/ares_210.html
@@ -1136,6 +1136,12 @@ Channels:
 </tr>
 <tr class='enumEntry'>
 <td class='enumKey'>
+<span>87 (mastercard)</span>
+</td>
+<td class='enumValue'>Transaction is excluded from Attempts Processing, because Device Channel is 3RI</td>
+</tr>
+<tr class='enumEntry'>
+<td class='enumKey'>
 <span>87 (visa)</span>
 </td>
 <td class='enumValue'>Transaction is excluded from Attempts Processing (includes non- reloadable pre-paid cards and Non- Payments (NPA))</td>

--- a/source/_static/ares_220.html
+++ b/source/_static/ares_220.html
@@ -1301,6 +1301,12 @@ Channels:
 </tr>
 <tr class='enumEntry'>
 <td class='enumKey'>
+<span>87 (mastercard)</span>
+</td>
+<td class='enumValue'>Transaction is excluded from Attempts Processing, because Device Channel is 3RI</td>
+</tr>
+<tr class='enumEntry'>
+<td class='enumKey'>
 <span>87 (visa)</span>
 </td>
 <td class='enumValue'>Transaction is excluded from Attempts Processing (includes non- reloadable pre-paid cards and Non- Payments (NPA))</td>

--- a/source/_static/rreq_210.html
+++ b/source/_static/rreq_210.html
@@ -933,6 +933,12 @@ Channels:
 </tr>
 <tr class='enumEntry'>
 <td class='enumKey'>
+<span>87 (mastercard)</span>
+</td>
+<td class='enumValue'>Transaction is excluded from Attempts Processing, because Device Channel is 3RI</td>
+</tr>
+<tr class='enumEntry'>
+<td class='enumKey'>
 <span>87 (visa)</span>
 </td>
 <td class='enumValue'>Transaction is excluded from Attempts Processing (includes non- reloadable pre-paid cards and Non- Payments (NPA))</td>

--- a/source/_static/rreq_220.html
+++ b/source/_static/rreq_220.html
@@ -1086,6 +1086,12 @@ Channels:
 </tr>
 <tr class='enumEntry'>
 <td class='enumKey'>
+<span>87 (mastercard)</span>
+</td>
+<td class='enumValue'>Transaction is excluded from Attempts Processing, because Device Channel is 3RI</td>
+</tr>
+<tr class='enumEntry'>
+<td class='enumKey'>
 <span>87 (visa)</span>
 </td>
 <td class='enumValue'>Transaction is excluded from Attempts Processing (includes non- reloadable pre-paid cards and Non- Payments (NPA))</td>


### PR DESCRIPTION
According to Mastercard's "AN 7603 Updating Smart Authentication Stand-In Logic for Identity Check", by 5 July 2023, Mastercard will begin rejecting authentication requests made with 3RI as Device Channel with `transStatusReason=87`.

This will help prevent successful frictionless authentication of transactions that are not appropriate for frictionless authentication.