### PR TITLE
Update browserLanguage max length to 35 for v2.3.1

### DIFF
--- a/source/_static/areq_231.html
+++ b/source/_static/areq_231.html
@@ -1481,7 +1481,7 @@
           </div>
           <div class="maxLength">
             Max length:
-            <code><span class="pre">8</span></code>
+            <code><span class="pre">35</span></code>
           </div>
         </div>
         <div class="scenario">


### PR DESCRIPTION
The spec clearly document this length:

<img width="1600" height="275" alt="image" src="https://github.com/user-attachments/assets/e8e778a9-1c86-4532-b8f1-3ed87f9d79cb" />
